### PR TITLE
ショートカットキーが途中から効かなくなる

### DIFF
--- a/capture_frame.py
+++ b/capture_frame.py
@@ -133,11 +133,24 @@ class CaptureFrame(ctk.CTkFrame):
         if self.original_capture_image is None:
             return
 
+        # 適切な画像サイズを計算
+        # NOTE
+        #   フレームが一度も表示されていない段階ではフレームサイズとして (1, 1) が報告される。
+        #   こういった特殊ケースで画像サイズが異常値になるのを防ぐため、最低保障値を付ける。
+        actual_image_width = max(
+            self.preview_label.winfo_width() - 2 * WIDGET_PADDING,
+            32
+        )
+        actual_image_height = max(
+            self.preview_label.winfo_height() - 2 * WIDGET_PADDING,
+            32
+        )
+
         # 画像をリサイズ
         pil_image = isotropic_scale_image_in_rectangle(
             self.original_capture_image,
-            self.preview_label.winfo_width() - 2 * WIDGET_PADDING,
-            self.preview_label.winfo_height() - 2 * WIDGET_PADDING
+            actual_image_width,
+            actual_image_height
         )
 
         # 画像をラベルに表示

--- a/capture_frame.py
+++ b/capture_frame.py
@@ -17,7 +17,10 @@ from pil_wrapper import (
     isotropic_scale_image_in_rectangle,
     save_pil_image_to_jpeg_file
 )
-from windows_wrapper import image_to_clipboard
+from windows_wrapper import (
+    image_to_clipboard,
+    register_global_hotkey_handler
+)
 
 
 class CaptureFrame(ctk.CTkFrame):
@@ -63,11 +66,8 @@ class CaptureFrame(ctk.CTkFrame):
         # リサイズ前のキャプチャ画像
         self.original_capture_image = None
 
-        # ホットキー用のバックグラウンドスレッドを開始
-        # NOTE
-        #   ホットキーのリスニングはメインスレッドで行うと、GUIがフリーズしてしまうので、バックグラウンドスレッドを使用する。
-        #   デーモンスレッドにすることで、メインスレッドが終了したときに自動的に終了する。
-        threading.Thread(target=self.listen_hotkey, daemon=True).start()
+        # グローバルホットキーを登録
+        register_global_hotkey_handler(self, self.on_preview_label_click, None)
 
 
     def on_preview_label_click(self, event) -> None:
@@ -107,15 +107,6 @@ class CaptureFrame(ctk.CTkFrame):
         :return: None
         '''
         self.update_preview_label()
-
-
-    def listen_hotkey(self) -> None:
-        '''
-        ホットキーをリスニングする。
-        :return: None
-        '''
-        keyboard.add_hotkey('ctrl+alt+p', lambda: self.on_preview_label_click(None))
-        keyboard.wait()
 
 
     def update_original_capture_image(self) -> None:

--- a/windows_wrapper.py
+++ b/windows_wrapper.py
@@ -11,6 +11,8 @@ from typing import (
 import re
 import threading
 import queue
+import warnings
+from inspect import cleandoc
 
 from PIL import Image
 
@@ -198,7 +200,15 @@ def register_global_hotkey_handler(
     def poll_ghk_event():
         if not ghk_event_queue.empty():
             ghk_event_queue.get()
-            handler(*args)
+            try:
+                handler(*args)
+            except Exception as e:
+                warnings.warn(cleandoc(f'''
+                Unexpected exception raised in poll_ghk_event.
+                Swallowing this and continue.
+                Exception detail:
+                {args}
+                '''))
         ctk_kind.after(10, poll_ghk_event)
 
     # ポーリング処理をキック


### PR DESCRIPTION
- グローバルホットキーをハンドルする方法を keyboard から win32gui.RegisterHotKey に変更したことで、グローバルホットキーが途中で効かなくなる問題を修正
- キャプチャタブを１度も表示してない時にグローバルホットキーでスクショを撮ると例外が出て失敗する問題を修正
- グローバルホットキー経由で呼び出したキャプチャ処理が失敗した場合、それ以降もグローバルホットキーが効くように修正（以前はキャプチャの失敗がグローバルホットキー関係の処理を巻き込んでいた）
- 