### PR TITLE
リリース版 exe でログがファイルにリダイレクトされるようにした

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ __pycache__
 /nime/
 /*.spec
 /src/utils/version_constants.py
+/log/

--- a/src/gui/aynime_issen_style_app.py
+++ b/src/gui/aynime_issen_style_app.py
@@ -9,27 +9,7 @@ from capture_frame import CaptureFrame
 from version_frame import VersionFrame
 from aynime_issen_style_model import CaptureMode, AynimeIssenStyleModel
 from utils.constants import WINDOW_MIN_WIDTH, WINDOW_MIN_HEIGHT, DEFAULT_FONT_NAME
-
-
-def resource_path(relative_path: str) -> str:
-    """
-    ファイル relative_path のリソースパスを生成する。
-    「直接実行した場合」と「 pyinstaller で生成した exe から実行された場合」の差異を吸収するための関数。
-
-    Args:
-        relative_path (str): 入力ファイル相対パス
-
-    Returns:
-        str: リソースパス
-            直接実行時は relative_path がそのまま返される。
-            pyinstaller で生成した exe から実行された場合は処理されたパスが返される。
-
-    """
-    if hasattr(sys, "_MEIPASS"):
-        # PyInstaller バンドル実行時
-        return os.path.join(sys._MEIPASS, relative_path)
-    else:
-        return os.path.join(os.path.abspath("."), relative_path)
+from utils.pyinstaller import resource_path
 
 
 class AynimeIssenStyleApp(ctk.CTk):

--- a/src/gui/main.py
+++ b/src/gui/main.py
@@ -1,10 +1,19 @@
 import customtkinter as ctk
 
 from aynime_issen_style_app import AynimeIssenStyleApp
-
+from utils.pyinstaller import is_frozen
+from utils.std import redirect_to_file
+import logging
 
 if __name__ == "__main__":
+    # ログファイルリダイレクト設定
+    if is_frozen():
+        redirect_to_file()
+
+    # カラーテーマを設定
     ctk.set_appearance_mode("Dark")
     ctk.set_default_color_theme("blue")
+
+    # CTk アプリを生成・開始
     app = AynimeIssenStyleApp()
     app.mainloop()

--- a/src/utils/constants.py
+++ b/src/utils/constants.py
@@ -7,7 +7,7 @@ WIDGET_PADDING = 4
 # ウィンドウの最小サイズ
 # NOTE
 #   最小サイズであると同時に初期サイズでもある
-#   8:5
+#   いろいろあって 8:5 になった
 WINDOW_MIN_WIDTH = 640
 WINDOW_MIN_HEIGHT = 400
 

--- a/src/utils/pyinstaller.py
+++ b/src/utils/pyinstaller.py
@@ -1,0 +1,32 @@
+import sys
+import os
+from pathlib import Path
+
+
+def is_frozen() -> bool:
+    """
+    PyInstaller にって凍結されたバイナリ内での実行であるかを調べる
+
+    Returns:
+        bool: 凍結バイナリなら True
+    """
+    return getattr(sys, "frozen", False)
+
+
+def resource_path(relative_path: str) -> str:
+    """
+    ファイル relative_path のリソースパスを生成する。
+    「直接実行した場合」と「 pyinstaller で凍結された exe から実行された場合」の差異を吸収するための関数。
+
+    Args:
+        relative_path (str): 入力ファイル相対パス
+
+    Returns:
+        str: リソースパス
+            pyinstaller で生成した exe から実行された場合は処理されたパスが返される。
+            直接実行時は relative_path が絶対パス化されて返される。
+    """
+    if is_frozen():
+        return os.path.join(sys._MEIPASS, relative_path)
+    else:
+        return os.path.join(Path.cwd(), relative_path)

--- a/src/utils/std.py
+++ b/src/utils/std.py
@@ -1,0 +1,40 @@
+import sys
+from pathlib import Path
+from datetime import datetime
+import logging
+
+
+def redirect_to_file() -> None:
+    """
+    プログラムの stdout, stderr がファイルにリダイレクトされるように設定する
+    ログローテーションも行われる
+    """
+    # ログディレクトリを作成
+    log_dir_path = Path.cwd() / "log"
+    if not log_dir_path.exists():
+        log_dir_path.mkdir()
+
+    # 既存ログファイルを列挙
+    existing_log_files = [p for p in log_dir_path.glob("*.log")]
+    existing_log_files.sort()
+
+    # 最大数から溢れないように、古い方のログファイルを削除
+    NUM_MAX_LOG_FILES = 10
+    num_overflow_log_files = max(0, len(existing_log_files) - NUM_MAX_LOG_FILES + 1)
+    for p in existing_log_files[:num_overflow_log_files]:
+        p.unlink()
+
+    # リダイレクト先ファイルパス
+    date_str = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
+    log_file_path = log_dir_path / (date_str + ".log")
+
+    # stdout, stderr をファイルへリダイレクト
+    sys.stdout = open(log_file_path, "w", encoding="utf-8", buffering=1)
+    sys.stderr = sys.stdout
+
+    # logging もファイルへ
+    logging.basicConfig(
+        level=logging.DEBUG,
+        format="%(asctime)s [%(levelname)s] %(message)s",
+        handlers=[logging.FileHandler(log_file_path, encoding="utf-8")],
+    )


### PR DESCRIPTION
- pyinstaller freezed exe での実行の場合 exe と同階層の log フォルルダにログがリダイレクトされる
- ログファイルは 10 個上限でローテーションされる
- ついでに、ビルド成果物（zip）内容の直下がフォルダになった（いままで exe が直下に置いてあった）